### PR TITLE
CSS var to control result "compactness"

### DIFF
--- a/lib/components/zack-result.js
+++ b/lib/components/zack-result.js
@@ -24,6 +24,7 @@ class ZackResult extends ZackComponent {
         display: block;
         border-top: 1px dotted black;
         height: 67px;
+        --zack-result-internal-compact-height: var(--zack-result-compact-height, 48px)
       }
       
       #wrapper {
@@ -33,11 +34,11 @@ class ZackResult extends ZackComponent {
       }
       
       :host([compact]) {
-        height: 48px;
+        height: var(--zack-result-internal-compact-height);
       }
       
       :host([compact]) #wrapper {
-        grid-auto-rows: 0 46px 0;
+        grid-auto-rows: 0 var(--zack-result-internal-compact-height) 0;
       }
       
       .fav {
@@ -50,7 +51,7 @@ class ZackResult extends ZackComponent {
         margin-top: 2px;
         margin-left: 30px;
         line-height: 110%;
-        height: 42px;
+        height: calc(var(--zack-result-internal-compact-height) - 2px);
         overflow: hidden;
       }
 
@@ -73,7 +74,7 @@ class ZackResult extends ZackComponent {
       }
 
       .main {
-        height: 46px;
+        height: var(--zack-result-internal-compact-height);
         grid-column: 2;
         grid-row: 2 / 3;
       }

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,11 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap-tour@0.12.0/build/js/bootstrap-tour.min.js" integrity="sha384-swE1ui2PD3Zxqnb59eKcqIfMV73b75VZk58qzfLlW/XNJLlFPlM1XlCUdE37wvk2" crossorigin="anonymous"></script>
+  <style>
+    body {
+      --zack-result-compact-height: 32px;
+    }
+  </style>
 </head>
 <body>
 <zack-search>


### PR DESCRIPTION
I'm adding this small option to make `[compact]`result rows more compact. For starters it's only the height, which can be explicitly controlled by overriding a type variable, for example globally for the entire page

```css
body {
  --zack-result-compact-height: 32px;
}
```

The default compact height is `48px`