### PR TITLE
refactor: use clownface for passing around the results

### DIFF
--- a/lib/components/ZackComponent.js
+++ b/lib/components/ZackComponent.js
@@ -1,5 +1,6 @@
 import { LitElement } from 'lit'
 import $rdf from 'rdf-ext'
+import { store } from '../store'
 
 export class ZackComponent extends LitElement {
   static get properties () {
@@ -12,6 +13,8 @@ export class ZackComponent extends LitElement {
 
   connectedCallback () {
     const event = {}
+    this.__loadShapes()
+
     this.dispatchEvent(new CustomEvent('zack-connect', {
       detail: event,
       composed: true
@@ -30,6 +33,16 @@ export class ZackComponent extends LitElement {
     event.zack.addEventListener('zack-init', function onInit (e) {
       setApp(e.detail.app)
       event.zack.removeEventListener('zack-init', onInit)
+    })
+  }
+
+  __loadShapes () {
+    this.querySelectorAll('[class=shape]').forEach(link => {
+      store.dispatch.core.parseShape({
+        id: link.id,
+        format: link.type,
+        serialized: fetch(link.href).then(res => res.text())
+      })
     })
   }
 }

--- a/lib/components/ZackComponent.js
+++ b/lib/components/ZackComponent.js
@@ -37,11 +37,23 @@ export class ZackComponent extends LitElement {
   }
 
   __loadShapes () {
-    this.querySelectorAll('[class=shape]').forEach(link => {
+    this.querySelectorAll('script[class=shape]').forEach(script => {
+      store.dispatch.core.parseShape({
+        id: script.id,
+        format: script.type,
+        serialized: script.text
+      })
+    })
+
+    this.querySelectorAll('link[class=shape]').forEach(link => {
       store.dispatch.core.parseShape({
         id: link.id,
         format: link.type,
-        serialized: fetch(link.href).then(res => res.text())
+        serialized: fetch(link.href, {
+          headers: {
+            accept: link.type
+          }
+        }).then(res => res.text())
       })
     })
   }

--- a/lib/components/zack-result-hierarchy.js
+++ b/lib/components/zack-result-hierarchy.js
@@ -78,9 +78,7 @@ class ZackResultHierarchy extends ZackComponent {
   }
 
   render () {
-    const page = this.graph
-    const { subject } = this
-    const hierarchy = this.getHierarchy(page, subject)
+    const hierarchy = this.getHierarchy(this.subject)
 
     let hierarchyString = html``
     let lvl
@@ -111,32 +109,29 @@ class ZackResultHierarchy extends ZackComponent {
     return html`<ul>${hierarchyString}</ul>`
   }
 
-  getHierarchy (graph, subject) {
-    const title = graph.match(subject, this.app.terms.title).toArray().shift()
-    const level = graph.match(subject, this.app.terms.level).toArray().shift()
-    let titleString
+  getHierarchy (ptr) {
+    let title = ptr.out(this.app.terms.title).values.shift()
+    const level = ptr.out(this.app.terms.level).values.shift()
 
     if (!level) {
       return []
     }
 
-    if (title) {
-      titleString = title.object.value
-    } else {
-      titleString = subject.value
-      console.warn('Missing title on ', subject.value)
+    if (!title) {
+      title = ptr.value
+      console.warn('Missing title on ', ptr.value)
     }
 
     let hierarchy = [{
-      subject: subject,
-      title: titleString,
-      level: level.object.value
+      subject: ptr.term,
+      title,
+      level
     }]
 
-    const relation = graph.match(subject, this.app.terms.relation).toArray().shift()
+    const relation = ptr.out(this.app.terms.relation).terms.shift()
 
     if (relation) {
-      hierarchy = this.getHierarchy(graph, relation.object).concat(hierarchy)
+      hierarchy = this.getHierarchy(ptr.node(relation)).concat(hierarchy)
     }
 
     return hierarchy

--- a/lib/components/zack-result-level.js
+++ b/lib/components/zack-result-level.js
@@ -32,12 +32,11 @@ class ZackResultLevel extends ZackComponent {
   }
 
   render () {
-    const page = this.graph
     const { subject } = this
 
     const faLevel = this.app.typeFilters
 
-    const levelString = page.match(subject, this.app.terms.level).toArray().shift().object.value
+    const levelString = subject.out(this.app.terms.level).values.shift()
     const levelShort = levelString.substring(levelString.lastIndexOf('/') + 1, levelString.length)
     const levelColor = colorHash.hex(levelShort)
 

--- a/lib/components/zack-result.js
+++ b/lib/components/zack-result.js
@@ -1,4 +1,6 @@
 import { css, html } from 'lit'
+import { sh } from '@tpluscode/rdf-ns-builders'
+import { findNodes } from 'clownface-shacl-path'
 import './zack-result-hierarchy'
 import './zack-result-time-tick'
 import './zack-result-level'
@@ -11,7 +13,10 @@ class ZackResult extends ZackComponent {
     return {
       compact: { type: Boolean, reflect: true },
       range: { type: Object },
-      subject: { type: Object }
+      subject: { type: Object },
+      shape: { type: Object },
+      properties: { type: Object },
+      parts: { type: Array }
     }
   }
 
@@ -26,8 +31,8 @@ class ZackResult extends ZackComponent {
       
       #wrapper {
         display: grid;
-        grid-template-columns: 32px repeat(4, 1fr);
-        grid-auto-rows: 19px 23px 23px;
+        grid-template-columns: var(--zack-result-columns, 32px 20px repeat(4, 1fr) var(--zack-result-thumbnail-width, 64px));
+        grid-auto-rows: var(--zack-result-rows, 19px 23px 23px);
       }
       
       :host([compact]) {
@@ -38,80 +43,10 @@ class ZackResult extends ZackComponent {
         grid-auto-rows: 0 var(--zack-result-internal-compact-height) 0;
       }
       
-      .fav {
-        grid-column: 1;
-        grid-row: 2 / 3;
+      [part=fav] {
+        grid-column: var(--zack-result-fav-grid-column, 1);
+        grid-row: var(--zack-result-fav-grid-row, 2 / 3);
         --spectrum-alias-border-size-thin: 0px;
-      }
-
-      .main > div {
-        margin-top: 2px;
-        margin-left: 30px;
-        line-height: 110%;
-        height: calc(var(--zack-result-internal-compact-height) - 2px);
-        overflow: hidden;
-      }
-
-      :host([compact]) .hierarchy ,
-      :host([compact]) .tags ,
-      :host([compact]) .other ,
-      :host([compact]) .thumbnail{
-        display: none;
-      }
-
-      .main a {
-        text-decoration: none;
-        color: black;
-      }
-      
-      .hierarchy {
-        grid-column: 2 / 6;
-        grid-row: 1 / 2;
-        overflow: hidden;
-      }
-
-      .main {
-        height: var(--zack-result-internal-compact-height);
-        grid-column: 2;
-        grid-row: 2 / 3;
-      }
-
-      :host([compact]) .main {
-        grid-column: 2 / 5;
-      }
-      
-      .reference {
-        grid-column: 4;
-        grid-row: 2;
-      }
-
-      :host([compact]) .reference {
-        grid-column: 5;
-      }
-      
-      .tags {
-        grid-column: 4;
-        grid-row: 2;
-      }
-      
-      .other {
-        grid-column: 4 / 5;
-        grid-row: 3;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      
-      .thumbnail {
-        grid-column: 5;
-        grid-row: 1 / 4;
-        max-width: 64px;
-        overflow: hidden;
-      }
-      
-      .thumbnail img {
-        height: 100%;
-        position: absolute;
-        right: 0
       }
 
       a {
@@ -121,109 +56,57 @@ class ZackResult extends ZackComponent {
     `
   }
 
+  constructor () {
+    super()
+    this.parts = []
+    this.properties = {}
+  }
+
+  async updated (_changedProperties) {
+    if ((_changedProperties.has('shape') || _changedProperties.has('subject')) && this.subject && this.shape) {
+      this.properties = this.shape
+        .out(sh.property)
+        .toArray()
+        .reduce((result, prop) => {
+          const name = prop.out(sh.name).value
+          const path = prop.out(sh.path)
+          if (name) {
+            return {
+              ...result,
+              [name]: findNodes(this.subject, path)
+            }
+          }
+
+          return result
+        }, {})
+    }
+  }
+
   render () {
     const { subject } = this
 
-    if (!subject) {
+    if (!subject || !this.shape) {
       return ''
     }
 
-    let title = subject.out(this.app.terms.title).values.shift()
-    if (!title) {
-      title = subject.value
-      console.log('Not good: Missing title on ', subject.value)
+    const partContext = {
+      html,
+      subject,
+      shape: this.shape
     }
-
-    const titleLink = html`<a target="_blank" href="${subject.value}">${title}</a>`
-
-    const referenceCode = subject.out(this.app.terms.referenceCode).values.shift() ||
-      subject.out(this.app.terms.recordID).values.shift()
-
-    const reference = html`<span><i>${referenceCode}</i></span>`
-
-    const conceptTags = subject.dataset.match(subject.term, this.app.terms.conceptTag).toArray()
-    const conceptTagDivs = html`<div class="result-tags">
-      ${(conceptTags || []).map(tag => html`
-        <zack-filter operator="="
-             .predicate="${tag.predicate}"
-             .value="${tag.object}"
-             class="filterable">${tag.object.value}</zack-filter>
-      `)}
-    </div>`
-
-    const url = subject.out(this.app.terms.isRepresentedBy).values.shift()
-    let urlLink = ''
-    if (url) {
-      urlLink = html`<span><a target="_blank" href="${url}"><i class="fa fa-external-link" title="Link to Archive"></i> </a></span>`
-    }
-
-    const description = subject.out(this.app.terms.description).values.shift()
-    let descSpan = ''
-    if (description) {
-      descSpan = html`<span>Description: ${description}</span>`
-    } else {
-      const note = subject.out(this.app.terms.note).values.shift()
-      if (note) {
-        descSpan = html`<span>Note: ${note}</span>`
-      }
-    }
-
-    const physicalForm = subject.out(this.app.terms.physicalForm).values.shift()
-    let physical = ''
-    if (physicalForm) {
-      physical = html`<span>${physicalForm}</span>`
-    }
-
-    const { intervalStarts, intervalEnds } = this.app.getResultInterval(subject)
-
-    let timeTick = ''
-    let timeRange = ''
-    if (intervalStarts) {
-      const timelineMargin = 40
-      const date = new Date(intervalStarts)
-      const range = this.range.end - this.range.start
-      const width = document.querySelector('zack-timeline').offsetWidth - timelineMargin
-      if (!isNaN(date.valueOf())) {
-        const offset = ((width / range) * (date - this.range.start)) + (timelineMargin / 2)
-        timeTick = html`<zack-result-time-tick .offset="${offset}"></zack-result-time-tick>`
-      }
-      let timeR
-      const intervalEndDate = new Date(intervalEnds)
-      if (intervalEnds && date.getFullYear() !== intervalEndDate.getFullYear()) {
-        timeR = html`${date.getFullYear()}-${intervalEndDate.getFullYear()}`
-      } else {
-        timeR = date.getFullYear()
-      }
-      timeRange = html`<span> (${timeR})</span>`
-    }
-
-    const thumbnailUri = this.app.getThumbnail?.(subject)
-
-    const thumbnail = thumbnailUri ? html`<img src="${thumbnailUri}" alt="${title}">` : ''
 
     return html`
       <style>
         @import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css");
       </style>
       <div id="wrapper">
-      <div class="fav">
+      <div part="fav">
         <zack-fav-menu .subject="${subject}"></zack-fav-menu>
       </div>
-      <div class="hierarchy">
-        ${timeTick}
-        <zack-result-hierarchy .subject="${subject}"></zack-result-hierarchy>
-      </div>
-      <div class="main">
-        <zack-result-level .title="${title}" .subject="${subject}"></zack-result-level>
-        <div>${titleLink}</div>
-      </div>
-      <div class="reference">
-        ${reference} ${timeRange}
-      </div>
-      <div class="tags">${conceptTagDivs}</div>
-      <div class="other">${urlLink} ${descSpan} ${physical}</div>
-      <div class="thumbnail">${thumbnail}</div>
-      </div>
+        
+      ${this.parts.map(part => html`<div part="${this.compact ? 'compact' : ''} ${part.name}">
+        ${part.render.call(this, partContext, this.properties)}
+      </div>`)}  
     `
   }
 }

--- a/lib/components/zack-result.js
+++ b/lib/components/zack-result.js
@@ -2,19 +2,16 @@ import { css, html } from 'lit'
 import './zack-result-hierarchy'
 import './zack-result-time-tick'
 import './zack-result-level'
-import { namedNode } from '@rdf-esm/data-model'
 import { ZackComponent } from './ZackComponent'
-import clownface from 'clownface'
 import './zack-fav-menu'
 import './zack-filter'
 
 class ZackResult extends ZackComponent {
   static get properties () {
     return {
-      graph: { type: Object },
       compact: { type: Boolean, reflect: true },
       range: { type: Object },
-      subject: { type: Object, converter: namedNode }
+      subject: { type: Object }
     }
   }
 
@@ -125,38 +122,26 @@ class ZackResult extends ZackComponent {
   }
 
   render () {
-    const page = this.graph
     const { subject } = this
 
-    if (!page || !subject) {
+    if (!subject) {
       return ''
     }
 
-    const title = page.match(subject, this.app.terms.title).toArray().shift()
-    let titleString = ''
-    if (title) {
-      titleString = title.object.value
-    } else {
-      titleString = subject.value
+    let title = subject.out(this.app.terms.title).values.shift()
+    if (!title) {
+      title = subject.value
       console.log('Not good: Missing title on ', subject.value)
     }
 
-    const titleLink = html`<a target="_blank" href="${subject.value}">${titleString}</a>`
+    const titleLink = html`<a target="_blank" href="${subject.value}">${title}</a>`
 
-    let referenceString = ''
-    const referenceCode = page.match(subject, this.app.terms.referenceCode).toArray().shift()
-    if (referenceCode) {
-      referenceString = referenceCode.object.value
-    } else {
-      const recordId = page.match(subject, this.app.terms.recordID).toArray().shift()
-      if (recordId) {
-        referenceString = recordId.object.value
-      }
-    }
+    const referenceCode = subject.out(this.app.terms.referenceCode).values.shift() ||
+      subject.out(this.app.terms.recordID).values.shift()
 
-    const reference = html`<span><i>${referenceString}</i></span>`
+    const reference = html`<span><i>${referenceCode}</i></span>`
 
-    const conceptTags = page.match(subject, this.app.terms.conceptTag).toArray()
+    const conceptTags = subject.dataset.match(subject.term, this.app.terms.conceptTag).toArray()
     const conceptTagDivs = html`<div class="result-tags">
       ${(conceptTags || []).map(tag => html`
         <zack-filter operator="="
@@ -166,36 +151,36 @@ class ZackResult extends ZackComponent {
       `)}
     </div>`
 
-    const url = page.match(subject, this.app.terms.isRepresentedBy).toArray().shift()
+    const url = subject.out(this.app.terms.isRepresentedBy).values.shift()
     let urlLink = ''
     if (url) {
-      urlLink = html`<span><a target="_blank" href="${url.object.value}"><i class="fa fa-external-link" title="Link to Archive"></i> </a></span>`
+      urlLink = html`<span><a target="_blank" href="${url}"><i class="fa fa-external-link" title="Link to Archive"></i> </a></span>`
     }
 
-    const description = page.match(subject, this.app.terms.description).toArray().shift()
+    const description = subject.out(this.app.terms.description).values.shift()
     let descSpan = ''
     if (description) {
-      descSpan = html`<span>Description: ${description.object.value}</span>`
+      descSpan = html`<span>Description: ${description}</span>`
     } else {
-      const note = page.match(subject, this.app.terms.note).toArray().shift()
+      const note = subject.out(this.app.terms.note).values.shift()
       if (note) {
-        descSpan = html`<span>Note: ${note.object.value}</span>`
+        descSpan = html`<span>Note: ${note}</span>`
       }
     }
 
-    const physicalForm = page.match(subject, this.app.terms.physicalForm).toArray().shift()
+    const physicalForm = subject.out(this.app.terms.physicalForm).values.shift()
     let physical = ''
     if (physicalForm) {
-      physical = html`<span>${physicalForm.object.value}</span>`
+      physical = html`<span>${physicalForm}</span>`
     }
 
-    const { intervalStarts, intervalEnds } = this.app.getResultInterval(page, subject)
+    const { intervalStarts, intervalEnds } = this.app.getResultInterval(subject)
 
     let timeTick = ''
     let timeRange = ''
     if (intervalStarts) {
       const timelineMargin = 40
-      const date = new Date(intervalStarts.object.value)
+      const date = new Date(intervalStarts)
       const range = this.range.end - this.range.start
       const width = document.querySelector('zack-timeline').offsetWidth - timelineMargin
       if (!isNaN(date.valueOf())) {
@@ -203,7 +188,7 @@ class ZackResult extends ZackComponent {
         timeTick = html`<zack-result-time-tick .offset="${offset}"></zack-result-time-tick>`
       }
       let timeR
-      const intervalEndDate = new Date(intervalEnds.object.value)
+      const intervalEndDate = new Date(intervalEnds)
       if (intervalEnds && date.getFullYear() !== intervalEndDate.getFullYear()) {
         timeR = html`${date.getFullYear()}-${intervalEndDate.getFullYear()}`
       } else {
@@ -212,10 +197,9 @@ class ZackResult extends ZackComponent {
       timeRange = html`<span> (${timeR})</span>`
     }
 
-    const pointer = clownface({ dataset: page }).node(subject)
-    const thumbnailUri = this.app.getThumbnail?.(pointer)
+    const thumbnailUri = this.app.getThumbnail?.(subject)
 
-    const thumbnail = thumbnailUri ? html`<img src="${thumbnailUri}" alt="${titleString}">` : ''
+    const thumbnail = thumbnailUri ? html`<img src="${thumbnailUri}" alt="${title}">` : ''
 
     return html`
       <style>
@@ -227,10 +211,10 @@ class ZackResult extends ZackComponent {
       </div>
       <div class="hierarchy">
         ${timeTick}
-        <zack-result-hierarchy .graph="${this.graph}" .subject="${subject}"></zack-result-hierarchy>
+        <zack-result-hierarchy .subject="${subject}"></zack-result-hierarchy>
       </div>
       <div class="main">
-        <zack-result-level .graph="${this.graph}" .title="${titleString}" .subject="${subject}"></zack-result-level>
+        <zack-result-level .title="${title}" .subject="${subject}"></zack-result-level>
         <div>${titleLink}</div>
       </div>
       <div class="reference">

--- a/lib/components/zack-results.js
+++ b/lib/components/zack-results.js
@@ -67,8 +67,7 @@ class ZackResults extends ZackComponent {
 
   __renderResult (result, i) {
     return html`<zack-result ?compact="${this.compact}"
-                             subject="${result?.subject?.value}"
-                             .graph="${result?.graph}"
+                             .subject="${result?.pointer}"
                              .range="${result?.range}"
     ></zack-result>`
   }

--- a/lib/components/zack-results.js
+++ b/lib/components/zack-results.js
@@ -1,16 +1,25 @@
 import { css, html } from 'lit'
 import { Layout1d } from '@lit-labs/virtualizer'
+import { connect } from '@captaincodeman/rdx'
+import { schema } from '@tpluscode/rdf-ns-builders'
+import { namedNode } from '@rdf-esm/data-model'
 import './zack-result'
 import { debounce } from 'debounce'
 import { ResultsController } from '../controller/ResultsController'
 import { ZackComponent } from './ZackComponent'
+import { store } from '../store'
 
-class ZackResults extends ZackComponent {
+const codeLinkTerm = namedNode('https://code.described.at/link')
+
+class ZackResults extends connect(store, ZackComponent) {
   static get properties () {
     return {
       app: { type: Object },
       results: { type: Array },
-      compact: { type: Boolean }
+      compact: { type: Boolean },
+      shape: { type: Object },
+      parts: { type: Array },
+      resultStyles: { type: String }
     }
   }
 
@@ -36,14 +45,58 @@ class ZackResults extends ZackComponent {
     super()
     this.compact = false
     this.results = new ResultsController(this)
+    this.parts = []
+    this.exportedParts = []
   }
 
-  updated (_changedProperties) {
+  async updated (_changedProperties) {
     if (_changedProperties.has('app')) {
       this.results.init()
       this.app.events.resultMetadata.on(() => {
         this.list.scrollToIndex(0)
       })
+    }
+
+    if (_changedProperties.has('shape') && this.shape) {
+      const scParts = this.shape
+        .out(schema.hasPart)
+        .toArray()
+
+      this.parts = await Promise.all(scParts
+        .map(async (part) => {
+          const name = part.out(schema.name).value
+          const codeLink = part.out(codeLinkTerm).value
+          const children = part.out(schema.hasPart).out(schema.name).values
+
+          if (name && codeLink) {
+            const render = (await import(/* webpackIgnore: true */ codeLink)).default
+
+            return {
+              name,
+              children,
+              render (...args) {
+                try {
+                  return render.call(this, ...args)
+                } catch (e) {
+                  return html`<pre style="display: none">
+${e.message}
+${e.stack}
+                  </pre>`
+                }
+              }
+            }
+          }
+
+          return { }
+        }))
+
+      this.exportedParts = this.parts.reduce((exported, part) => {
+        return [
+          ...exported,
+          part.name,
+          ...part.children.map(child => `${part.name}-${child}`)
+        ]
+      }, [])
     }
   }
 
@@ -65,15 +118,25 @@ class ZackResults extends ZackComponent {
     return this.compact ? 47 : 67
   }
 
-  __renderResult (result, i) {
+  __renderResult (result) {
     return html`<zack-result ?compact="${this.compact}"
                              .subject="${result?.pointer}"
                              .range="${result?.range}"
+                             .shape="${this.shape}"
+                             .parts="${this.parts}"
+                             part="result"
+                             exportparts="fav,compact,${this.exportedParts.join(',')}"
     ></zack-result>`
   }
 
   listScrolled (e) {
     this.results.load(e.detail.firstVisible)
+  }
+
+  mapState (state) {
+    return {
+      shape: state.core.shapes.result
+    }
   }
 }
 

--- a/lib/components/zack-search.js
+++ b/lib/components/zack-search.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit'
+import { css, html } from 'lit'
 import Zack from '../zack'
 import '@spectrum-web-components/theme/theme-light.js'
 import '@spectrum-web-components/theme/scale-medium.js'
@@ -8,10 +8,11 @@ import '@spectrum-web-components/toast/sp-toast.js'
 import './zack-notes-dialog'
 import { connect } from '@captaincodeman/rdx'
 import { store } from '../store'
+import { ZackComponent } from './ZackComponent'
 
 const Options = Symbol('zack options')
 
-class ZackSearch extends connect(store, LitElement) {
+class ZackSearch extends connect(store, ZackComponent) {
   static get properties () {
     return {
       app: { type: Object },
@@ -66,10 +67,8 @@ class ZackSearch extends connect(store, LitElement) {
   }
 
   connectedCallback () {
-    super.connectedCallback()
     this.addEventListener('zack-connect', this.__childConnected.bind(this), { capture: true })
-
-    this.__loadShapes()
+    super.connectedCallback()
 
     store.dispatch.search.addListener(() => {
       this.querySelector('zack-results').results.init()
@@ -105,16 +104,6 @@ class ZackSearch extends connect(store, LitElement) {
 
   __childConnected (e) {
     e.detail.zack = this
-  }
-
-  __loadShapes () {
-    this.querySelectorAll('script[class=shape]').forEach(script => {
-      store.dispatch.core.parseShape({
-        id: script.id,
-        format: script.type,
-        serialized: script.text
-      })
-    })
   }
 
   mapState (state) {

--- a/lib/controller/ResultsController.js
+++ b/lib/controller/ResultsController.js
@@ -1,5 +1,6 @@
 import { rdf } from '@tpluscode/rdf-ns-builders'
 import { namedNode } from '@rdf-esm/data-model'
+import clownface from 'clownface'
 import { SparqlSearchResultList } from '../SparqlSearchResult'
 import { store } from '../store'
 
@@ -78,13 +79,14 @@ export class ResultsController {
 
     this.array.splice(firstNotLoaded, pageSize, ...new Array(pageSize).map(() => ({})))
 
-    const graph = await this.sparqlList.fetchPage(firstNotLoaded)
-    const subjects = this.sparqlList.resultSubjects(graph)
+    const dataset = await this.sparqlList.fetchPage(firstNotLoaded)
+    const subjects = this.sparqlList.resultSubjects(dataset)
+
+    const graph = clownface({ dataset })
 
     const { start, end } = this.sparqlList || {}
     this.array.splice(firstNotLoaded, subjects.length, ...subjects.map(subject => ({
-      graph,
-      subject,
+      pointer: graph.node(subject),
       range: { start, end }
     })))
 

--- a/lib/controller/ResultsController.js
+++ b/lib/controller/ResultsController.js
@@ -101,10 +101,7 @@ export class ResultsController {
 
     const exported = this.array.reduce((prev, row) => {
       if (!row) return prev
-      const { graph, subject } = row
-
-      const ptr = clownface({ dataset: graph, term: subject })
-      const csvRow = [...properties.map(({ path }) => `"${findNodes(ptr, path)}"`), `"${ptr.value || ''}"`].join(',')
+      const csvRow = [...properties.map(({ path }) => `"${findNodes(row.pointer, path)}"`), `"${row.pointer.value || ''}"`].join(',')
 
       return [...prev, csvRow]
     }, [[...properties.map(({ name }, index) => `"${name || `COLUMN ${index + 1}`}"`), '"ID"'].join(',')])

--- a/lib/store/models/core.js
+++ b/lib/store/models/core.js
@@ -1,12 +1,18 @@
 import { createModel } from '@captaincodeman/rdx'
 import produce from 'immer'
+import { parsers } from '@rdf-esm/formats-common'
+import toStream from 'string-to-stream'
+import clownface from 'clownface'
+import $rdf from 'rdf-ext'
+import { sh } from '@tpluscode/rdf-ns-builders/strict'
 
 export const core = createModel({
   state: {
     toast: {
       open: false,
       message: ''
-    }
+    },
+    shapes: {}
   },
   reducers: {
     hideMessage: produce((state) => {
@@ -20,6 +26,23 @@ export const core = createModel({
         message,
         action
       }
+    }),
+    setShape: produce((draft, { id, shape }) => {
+      draft.shapes[id] = shape
     })
+  },
+  effects (store) {
+    const dispatch = store.getDispatch()
+
+    return {
+      async parseShape ({ id, format, serialized }) {
+        const quadStream = parsers.import(format, toStream(await serialized))
+        if (quadStream) {
+          const dataset = await $rdf.dataset().import(quadStream)
+          const [shape] = clownface(({ dataset })).has(sh.property).toArray()
+          dispatch.core.setShape({ id, shape })
+        }
+      }
+    }
   }
 })

--- a/lib/zack-result.css
+++ b/lib/zack-result.css
@@ -1,0 +1,64 @@
+zack-results::part(compact hierarchy) ,
+zack-results::part(compact tags) ,
+zack-results::part(compact other) ,
+zack-results::part(compact thumbnail) {
+  display: none;
+}
+
+zack-results::part(hierarchy) {
+  grid-column: 2 / 7;
+  grid-row: 1;
+  overflow: hidden;
+}
+
+zack-results::part(result-level) {
+  grid-column: 2;
+  grid-row: 2 / 3;
+}
+
+zack-results::part(main) {
+  grid-column: 3;
+  grid-row: 2 / 4;
+  padding-left: 10px;
+  overflow: hidden;
+}
+
+zack-results::part(compact main) {
+  grid-column: 3 / 6;
+  line-height: 110%;
+  padding-top: 2px;
+}
+
+zack-results::part(reference) {
+  grid-column: 5;
+  grid-row: 2;
+}
+
+zack-results::part(compact reference) {
+  grid-column: 6;
+}
+
+zack-results::part(tags) {
+  grid-column: 6;
+  grid-row: 2;
+}
+
+zack-results::part(other) {
+  grid-column: 5 / 6;
+  grid-row: 3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+zack-results::part(thumbnail) {
+  grid-column: 7;
+  grid-row: 1 / 4;
+  max-width: var(--zack-result-thumbnail-width, 64px);
+  overflow: hidden;
+}
+
+zack-results::part(thumbnail-img) {
+  height: 100%;
+  position: absolute;
+  right: 0
+}

--- a/lib/zack.js
+++ b/lib/zack.js
@@ -72,13 +72,13 @@ Zack.prototype.init = function () {
   return this.initPlugins()
 }
 
-Zack.prototype.getResultInterval = function (page, subject) {
+Zack.prototype.getResultInterval = function (pointer) {
   if (typeof this.options.getResultInterval === 'function') {
-    return this.options.getResultInterval.call(this, page, subject)
+    return this.options.getResultInterval.call(this, pointer)
   }
 
-  const intervalStarts = page.match(subject, this.terms.intervalStarts).toArray().shift()
-  const intervalEnds = page.match(subject, this.terms.intervalEnds).toArray().shift()
+  const intervalStarts = pointer.out(this.terms.intervalStarts).values.shift()
+  const intervalEnds = pointer.out(this.terms.intervalEnds).values.shift()
 
   return {
     intervalStarts, intervalEnds

--- a/lib/zack.js
+++ b/lib/zack.js
@@ -71,16 +71,3 @@ Zack.prototype.init = function () {
 
   return this.initPlugins()
 }
-
-Zack.prototype.getResultInterval = function (pointer) {
-  if (typeof this.options.getResultInterval === 'function') {
-    return this.options.getResultInterval.call(this, pointer)
-  }
-
-  const intervalStarts = pointer.out(this.terms.intervalStarts).values.shift()
-  const intervalEnds = pointer.out(this.terms.intervalEnds).values.shift()
-
-  return {
-    intervalStarts, intervalEnds
-  }
-}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tpluscode/sparql-builder": "^0.3.16",
     "cancelable-fetch": "^1.0.0",
     "clownface": "^1.0.0",
+    "clownface-shacl-path": "^1.2.2",
     "color-hash": "^1.0.3",
     "crab-event": "^0.1.0",
     "d3": "^5",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@captaincodeman/rdx": "^1.0.0-rc.9",
     "@lit-labs/virtualizer": "^0.6.0",
     "@rdf-esm/data-model": "^0.5.4",
+    "@rdf-esm/formats-common": "^0.5.5",
     "@spectrum-web-components/action-menu": "^0.11.1",
     "@spectrum-web-components/dialog": "^0.6.14",
     "@spectrum-web-components/menu": "^0.9.1",

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap-tour@0.12.0/build/js/bootstrap-tour.min.js" integrity="sha384-swE1ui2PD3Zxqnb59eKcqIfMV73b75VZk58qzfLlW/XNJLlFPlM1XlCUdE37wvk2" crossorigin="anonymous"></script>
-  <link rel="stylesheet" href="../lib/zack.css"></style>
+  <link rel="stylesheet" href="zack.css">
+  <link rel="stylesheet" href="zack-result.css">
   <style>
     body {
       --zack-result-compact-height: 32px;
@@ -90,6 +91,8 @@
         <div id="scrollArea" class="clusterize-scroll">
           <zack-results id="contentArea" class="clusterize-content">
             <div class="clusterize-no-data">Loading data…</div>
+
+            <link id="result" type="text/turtle" class="shape" rel="preload nofollow" href="shape/result.ttl">
           </zack-results>
         </div>
       </div>

--- a/public/index.html
+++ b/public/index.html
@@ -110,7 +110,7 @@
           <zack-results id="contentArea" class="clusterize-content">
             <div class="clusterize-no-data">Loading data…</div>
 
-            <link id="result" type="text/turtle" class="shape" rel="preload nofollow" href="shape/result.ttl">
+            <link id="result" type="text/turtle" class="shape" href="shape/result.ttl">
           </zack-results>
         </div>
       </div>

--- a/public/shape/result.ttl
+++ b/public/shape/result.ttl
@@ -1,0 +1,88 @@
+prefix time: <http://www.w3.org/2006/time#>
+prefix dcterms: <http://purl.org/dc/terms/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix zack: <http://voc.zazuko.com/zack#>
+prefix code: <https://code.described.at/>
+prefix schema: <http://schema.org/>
+prefix rico: <https://www.ica.org/standards/RiC/ontology#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix iiif: <http://iiif.io/api/presentation/3#>
+prefix alod: <http://data.alod.ch/alod/>
+prefix locah: <http://data.archiveshub.ac.uk/def/>
+
+[
+  sh:property
+    [
+      sh:name "thumbnail" ;
+      sh:path ( rico:hasInstantiation rdfs:seeAlso iiif:thumbnail ) ;
+    ],
+    [
+      sh:name "physicalForm" ;
+      sh:path alod:physicalForm ;
+    ],
+    [
+      sh:name "url" ;
+      sh:path locah:isRepresentedBy ;
+    ],
+    [
+      sh:name "description" ;
+      sh:path dcterms:description ;
+    ],
+    [
+      sh:name "note" ;
+      sh:path locah:note ;
+    ],
+    [
+      sh:name "title" ;
+      sh:path dcterms:title ;
+    ],
+    [
+      sh:name "conceptTags" ;
+      sh:path alod:conceptTag ;
+    ],
+    [
+      sh:name "referenceCode" ;
+      sh:path
+        [
+          sh:alternativePath ( alod:referenceCode alod:recordId ) ;
+        ] ;
+    ],
+    [
+      sh:name "intervalStarts" ;
+      sh:path time:intervalStarts ;
+    ],
+    [
+      sh:name "intervalEnds" ;
+      sh:path time:intervalEnds ;
+    ] ;
+  schema:hasPart
+    [
+      schema:name "thumbnail" ;
+      code:link "/templates/thumbnail.js" ;
+      schema:hasPart [ schema:name "img" ] ;
+    ],
+    [
+      schema:name "other" ;
+      code:link "/templates/other.js" ;
+    ],
+    [
+      schema:name "tags" ;
+      code:link "/templates/tags.js" ;
+    ],
+    [
+      schema:name "reference" ;
+      code:link "/templates/reference.js" ;
+    ],
+    [
+      schema:name "main" ;
+      code:link "/templates/main.js" ;
+    ],
+    [
+      schema:name "result-level" ;
+      code:link "/templates/result-level.js" ;
+    ],
+    [
+      schema:name "hierarchy" ;
+      code:link "/templates/hierarchy.js" ;
+    ] ;
+] .

--- a/public/templates/hierarchy.js
+++ b/public/templates/hierarchy.js
@@ -1,0 +1,18 @@
+export default function ({ html, subject }, { intervalStarts }) {
+  let timeTick = ''
+  if (intervalStarts?.value) {
+    const timelineMargin = 40
+    const date = new Date(intervalStarts.value)
+    const range = this.range.end - this.range.start
+    const width = document.querySelector('zack-timeline').offsetWidth - timelineMargin
+    if (!isNaN(date.valueOf())) {
+      const offset = ((width / range) * (date - this.range.start)) + (timelineMargin / 2)
+      timeTick = html`<zack-result-time-tick .offset="${offset}"></zack-result-time-tick>`
+    }
+  }
+
+  return html`
+    ${timeTick}
+    <zack-result-hierarchy .subject="${subject}"></zack-result-hierarchy>
+  `
+}

--- a/public/templates/main.js
+++ b/public/templates/main.js
@@ -1,0 +1,6 @@
+export default function ({ html, subject }, { title }) {
+  return html`<a target="_blank" 
+                 href="${subject.value}"
+                 style="color: var(--zack-result-main-anchor-color, black); text-decoration: none;"
+  >${title?.value}</a>`
+}

--- a/public/templates/other.js
+++ b/public/templates/other.js
@@ -1,0 +1,20 @@
+export default function ({ html, subject }, { description, note, url, physicalForm }) {
+  let physical = ''
+  if (physicalForm?.value) {
+    physical = html`<span>${physicalForm}</span>`
+  }
+
+  let urlLink = ''
+  if (url?.value) {
+    urlLink = html`<span><a target="_blank" href="${url}"><i class="fa fa-external-link" title="Link to Archive"></i> </a></span>`
+  }
+
+  let descSpan = ''
+  if (description?.value) {
+    descSpan = html`<span>Description: ${description}</span>`
+  } else if (note?.value) {
+    descSpan = html`<span>Note: ${note}</span>`
+  }
+
+  return html`${urlLink} ${descSpan} ${physical}`
+}

--- a/public/templates/reference.js
+++ b/public/templates/reference.js
@@ -1,0 +1,18 @@
+export default function ({ html, subject }, { referenceCode, intervalStarts, intervalEnds }) {
+  const reference = html`<span><i>${referenceCode?.value}</i></span>`
+
+  let timeRange = ''
+  if (intervalStarts?.value) {
+    let timeR
+    const date = new Date(intervalStarts.value)
+    let intervalEndDate
+    if (intervalEnds?.value && date.getFullYear() !== (intervalEndDate = new Date(intervalEnds.value)).getFullYear()) {
+      timeR = html`${date.getFullYear()}-${intervalEndDate.getFullYear()}`
+    } else {
+      timeR = date.getFullYear()
+    }
+    timeRange = html`<span> (${timeR})</span>`
+  }
+
+  return html`${reference} ${timeRange}`
+}

--- a/public/templates/result-level.js
+++ b/public/templates/result-level.js
@@ -1,0 +1,5 @@
+export default function ({ html, subject }, { title }) {
+  return html`
+    <zack-result-level .title="${title?.value}" .subject="${subject}"></zack-result-level>
+  `
+}

--- a/public/templates/tags.js
+++ b/public/templates/tags.js
@@ -1,0 +1,18 @@
+import { sh } from 'https://jspm.dev/@tpluscode/rdf-ns-builders'
+
+export default function ({ html, shape }, { conceptTags }) {
+  const predicate = shape
+    .out(sh.property)
+    .has(sh.name, 'conceptTags')
+    .out(sh.path)
+    .term
+
+  return html`<div class="result-tags">
+      ${(conceptTags?.terms || []).map(tag => html`
+        <zack-filter operator="="
+             .predicate="${predicate}"
+             .value="${tag}"
+             class="filterable">${tag.value}</zack-filter>
+      `)}
+    </div>`
+}

--- a/public/templates/thumbnail.js
+++ b/public/templates/thumbnail.js
@@ -1,0 +1,3 @@
+export default function ({ html }, { thumbnail, title }) {
+  return thumbnail?.value ? html`<img part="thumbnail-img" src="${thumbnail.value}" alt="${title}">` : ''
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,7 +56,10 @@ module.exports = (env, argv) => {
       plugins: [
         new CopyPlugin({
           patterns: [
-            { from: 'lib/zack.css' }
+            { from: 'lib/zack.css' },
+            { from: 'lib/zack-result.css' },
+            { from: 'public/shape', to: 'shape' },
+            { from: 'public/templates', to: 'templates' }
           ]
         })
       ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,6 +1110,18 @@
   dependencies:
     "@rdfjs/data-model" "^1.2"
 
+"@rdf-esm/formats-common@^0.5.5":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@rdf-esm/formats-common/-/formats-common-0.5.5.tgz#52d9aa49434072601b0210d101e48230e6547e51"
+  integrity sha512-kbz7ER2WdyL72Y+OZINrZtBFSTAN0brdX3IMcagN+VXliv4TJwsIokVexdBY/b+Fl4W0HG2hZe4FeiB18Myu0g==
+  dependencies:
+    "@rdf-esm/sink-map" "^0.5.4"
+    "@rdfjs/parser-jsonld" "^1.2.1"
+    "@rdfjs/parser-n3" "^1.1.4"
+    "@rdfjs/serializer-jsonld" "^1.2.2"
+    "@rdfjs/serializer-ntriples" "^1.0.3"
+    rdfxml-streaming-parser "^1.3.6"
+
 "@rdf-esm/namespace@^0.5.1":
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@rdf-esm/namespace/-/namespace-0.5.3.tgz#013ae57f410a885536087eb2ffd8ffb1e913a5af"
@@ -1118,6 +1130,13 @@
     "@rdf-esm/data-model" "^0.5.1"
     "@rdfjs/namespace" "^1.1.0"
     "@types/rdfjs__namespace" "*"
+
+"@rdf-esm/sink-map@^0.5.4":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@rdf-esm/sink-map/-/sink-map-0.5.4.tgz#b88970bcd69da6e9e7c9dcd138824b965d738759"
+  integrity sha512-2ECH1+Jd7691n0zsCO3NMNkz1ruwAiai49hDGXNnj2TObkLierApa37QGo2+B/LGYckpocJYy90+vIEMSrxlFA==
+  dependencies:
+    readable-stream "^3.6.0"
 
 "@rdf-esm/term-map@^0.5.0":
   version "0.5.1"
@@ -1168,6 +1187,17 @@
   dependencies:
     "@rdfjs/data-model" "^1.1.0"
 
+"@rdfjs/parser-jsonld@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rdfjs/parser-jsonld/-/parser-jsonld-1.2.1.tgz#fa4fa2f0b84b05eb326bd904f1d8788237cf40d3"
+  integrity sha512-m8WQBacXaU2qPgf+rPEqit4EiEjBxpohvDEG4aF7YvFAT6uEto3lHu7ilKcMKpLfMKmbXp4v6KzJXm9yvockNw==
+  dependencies:
+    "@rdfjs/data-model" "^1.0.1"
+    "@rdfjs/sink" "^1.0.2"
+    concat-stream "^2.0.0"
+    jsonld "^1.8.1"
+    readable-stream "^3.6.0"
+
 "@rdfjs/parser-n3@^1.1.3", "@rdfjs/parser-n3@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@rdfjs/parser-n3/-/parser-n3-1.1.4.tgz#7f8844c8a2fc62e7d1e40d7daf99a1af025a451d"
@@ -1179,7 +1209,25 @@
     readable-stream "^3.6.0"
     readable-to-readable "^0.1.0"
 
-"@rdfjs/sink@^1.0.2":
+"@rdfjs/serializer-jsonld@^1.2.2":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@rdfjs/serializer-jsonld/-/serializer-jsonld-1.2.3.tgz#643908db1211667f0c516f05fb20ce04f7ca49a0"
+  integrity sha512-Y6jGvXvtI4eIpHIizkY6WQnwUZNWcNfkwO4ZVTIGZpc7mHrlBMaXpcXc3f6XOBVeeb4k1dNy7Fqu2CL0B5+Uew==
+  dependencies:
+    "@rdfjs/namespace" "^1.1.0"
+    "@rdfjs/sink" "^1.0.3"
+    readable-stream "^3.6.0"
+
+"@rdfjs/serializer-ntriples@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rdfjs/serializer-ntriples/-/serializer-ntriples-1.0.3.tgz#2e48ef23591a3f982a7e658bdf70d34737496d0a"
+  integrity sha512-XXFgzNJyYrix0YgysqYowKw40hCJ+zeVqA/CGgO3y5XyKY+NL/VJJELMn7cTwjJteiLVCgRNAvaUVn4CjJ2PCg==
+  dependencies:
+    "@rdfjs/sink" "^1.0.3"
+    "@rdfjs/to-ntriples" "^1.0.2"
+    readable-to-readable "^0.1.0"
+
+"@rdfjs/sink@^1.0.2", "@rdfjs/sink@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@rdfjs/sink/-/sink-1.0.3.tgz#cdbb4ecf0ff34e6ad6c301a5bc221508c820568c"
   integrity sha512-2KfYa8mAnptRNeogxhQqkWNXqfYVWO04jQThtXKepySrIwYmz83+WlevQtA4VDLFe+kFd2TwgL29ekPe5XVUfA==
@@ -1474,7 +1522,7 @@
     commander "^7.2.0"
     fs-extra "^10.0.0"
 
-"@tpluscode/rdf-string@^0.2.16":
+"@tpluscode/rdf-string@^0.2.16", "@tpluscode/rdf-string@^0.2.24":
   version "0.2.24"
   resolved "https://registry.yarnpkg.com/@tpluscode/rdf-string/-/rdf-string-0.2.24.tgz#9d9fcafca2b2cfdf2bf0e515f9136feb8e221c7a"
   integrity sha512-eD8vpspwDP1Y+Pxp+ohFVCALd7OyT91m4KzjTJjtGT1kONXyM+6ygKm5EDsicScsyS64rlWOD8uAJJazoi65xg==
@@ -2021,7 +2069,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -2220,6 +2268,18 @@ asn1.js@^5.2.0:
     minimalistic-assert "^1.0.0"
     safer-buffer "^2.1.0"
 
+asn1@~0.2.3:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
+  integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
+  dependencies:
+    safer-buffer "~2.1.0"
+
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
+
 assert@^1.1.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
@@ -2260,10 +2320,25 @@ async@^2.6.2:
   dependencies:
     lodash "^4.17.14"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
+
+aws4@^1.8.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
+  integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
 babel-extract-comments@^1.0.0:
   version "1.0.0"
@@ -2383,6 +2458,13 @@ batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=
+
+bcrypt-pbkdf@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+  integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
+  dependencies:
+    tweetnacl "^0.14.3"
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -2748,6 +2830,16 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001033, caniuse-lite@^1.0.30001248:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz#6853a606ec50893115db660f82c094d18f096d85"
   integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
 
+canonicalize@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-1.0.5.tgz#b43b390ce981d397908bb847c3a8d9614323a47b"
+  integrity sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA==
+
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -2874,6 +2966,15 @@ clone@^2.1.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
+clownface-shacl-path@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/clownface-shacl-path/-/clownface-shacl-path-1.2.2.tgz#0a3b8d29b52402e5ed42521fbd8cbae4329e4ea4"
+  integrity sha512-vXrmPf5sM1M84k2r1O1ud14Zx/5yLBCWWqpam0y34r77tejEK5FwYjq5qXqrwSqosLEr53KbptbqHZvHKeFYjA==
+  dependencies:
+    "@rdf-esm/term-set" "^0.5.0"
+    "@tpluscode/rdf-ns-builders" "^1.0.0"
+    "@tpluscode/rdf-string" "^0.2.24"
+
 clownface@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/clownface/-/clownface-1.4.0.tgz#fc6018bd50459164c55d0f5916f8614fbdda11f2"
@@ -2928,6 +3029,13 @@ colorette@^1.2.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.3.0.tgz#ff45d2f0edb244069d3b772adeb04fed38d0a0af"
   integrity sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==
+
+combined-stream@^1.0.6, combined-stream@~1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 command-line-args@^5.0.2:
   version "5.2.0"
@@ -3017,6 +3125,16 @@ concat-stream@^1.5.0, concat-stream@^1.6.0:
     buffer-from "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
+concat-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-2.0.0.tgz#414cf5af790a48c60ab9be4527d56d5e41133cb1"
+  integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
 connect-history-api-fallback@^1.6.0:
@@ -3146,7 +3264,7 @@ core-js@^2.4.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
-core-util-is@~1.0.0:
+core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
@@ -3505,6 +3623,13 @@ d3@^5:
     d3-voronoi "1"
     d3-zoom "1"
 
+dashdash@^1.12.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
+  dependencies:
+    assert-plus "^1.0.0"
+
 debounce@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
@@ -3629,6 +3754,11 @@ del@^4.0.0, del@^4.1.1:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -3760,6 +3890,14 @@ dynamic-import-polyfill@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dynamic-import-polyfill/-/dynamic-import-polyfill-0.1.1.tgz#e1f9eb1876ee242bd56572f8ed4df768e143083f"
   integrity sha512-m953zv0w5oDagTItWm6Auhmk/pY7EiejaqiVbnzSS3HIjh1FCUeK7WzuaVtWPNs58A+/xpIE+/dVk6pKsrua8g==
+
+ecc-jsbn@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+  integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
+  dependencies:
+    jsbn "~0.1.0"
+    safer-buffer "^2.1.0"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -4386,6 +4524,11 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -4399,6 +4542,16 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+extsprintf@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+  integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
+
+extsprintf@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -4609,6 +4762,20 @@ for-in@^1.0.2:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
+forever-agent@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+  integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
 forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
@@ -4745,6 +4912,13 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
+getpass@^0.1.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
+  dependencies:
+    assert-plus "^1.0.0"
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -4871,6 +5045,19 @@ handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
   integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
+
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+  integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
+
+har-validator@~5.1.3:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
+  dependencies:
+    ajv "^6.12.3"
+    har-schema "^2.0.0"
 
 has-bigints@^1.0.1:
   version "1.0.1"
@@ -5087,6 +5274,15 @@ http-proxy@^1.17.0:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
+
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
 
 https-browserify@^1.0.0:
   version "1.0.0"
@@ -5510,6 +5706,11 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.2"
 
+is-typedarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -5554,6 +5755,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isstream@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
 jest-worker@^25.4.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-25.5.0.tgz#2611d071b79cea0f43ee57a3d118593ac1547db1"
@@ -5574,6 +5780,11 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+jsbn@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+  integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -5600,6 +5811,11 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
+json-schema@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -5611,6 +5827,11 @@ json-stable-stringify@^1.0.1:
   integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
   dependencies:
     jsonify "~0.0.0"
+
+json-stringify-safe@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 json3@^3.3.3:
   version "3.3.3"
@@ -5652,6 +5873,17 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
+jsonld@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-1.8.1.tgz#55ea541b22b8af5a5d6a5e32328e3f2678148882"
+  integrity sha512-f0rusl5v8aPKS3jApT5fhYsdTC/JpyK1PoJ+ZtYYtZXoyb1J0Z///mJqLwrfL/g4NueFSqPymDYIi1CcSk7b8Q==
+  dependencies:
+    canonicalize "^1.0.1"
+    rdf-canonize "^1.0.2"
+    request "^2.88.0"
+    semver "^5.6.0"
+    xmldom "0.1.19"
+
 jsonparse@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -5665,6 +5897,16 @@ jsonstream2@^3.0.0:
     jsonparse "1.3.1"
     through2 "^3.0.1"
     type-component "0.0.1"
+
+jsprim@^1.2.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
+  integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
+  dependencies:
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.2.3"
+    verror "1.10.0"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.2.0"
@@ -6150,7 +6392,7 @@ mime-db@1.49.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.49.0.tgz#f3dfde60c99e9cf3bc9701d687778f537001cbed"
   integrity sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==
 
-mime-types@^2.1.18, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.24:
+mime-types@^2.1.12, mime-types@^2.1.18, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.32"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.32.tgz#1d00e89e7de7fe02008db61001d9e02852670fd5"
   integrity sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==
@@ -6460,6 +6702,11 @@ npm-run-path@^2.0.0:
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
@@ -6871,6 +7118,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
@@ -7098,6 +7350,11 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
+psl@^1.1.28:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
+  integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
+
 public-encrypt@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
@@ -7145,7 +7402,7 @@ punycode@^1.2.4:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -7154,6 +7411,11 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
+qs@~6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -7213,6 +7475,14 @@ raw-loader@^4.0.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+rdf-canonize@^1.0.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/rdf-canonize/-/rdf-canonize-1.2.0.tgz#9872b2cc6ed92a9969e834f9f042addaf0d4f7f9"
+  integrity sha512-MQdcRDz4+82nUrEb3hNQangBDpmep15uMmnWclGi/1KS0bNVc8oHpoNI0PFLHZsvwgwRzH31bO1JAScqUAstvw==
+  dependencies:
+    node-forge "^0.10.0"
+    semver "^6.3.0"
+
 rdf-data-factory@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/rdf-data-factory/-/rdf-data-factory-1.1.0.tgz#d0510b9f100dd79e94f29559a12d4a5a585054d6"
@@ -7258,6 +7528,16 @@ rdf-transform-triple-to-quad@^1.0.2:
   dependencies:
     "@rdfjs/data-model" "^1.1.2"
     readable-stream "^3.5.0"
+
+rdfxml-streaming-parser@^1.3.6:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.5.0.tgz#485af3a01abc2dc49149b8758da9a12351d34348"
+  integrity sha512-pnt+7NgeqCMd2/rub+dqxzYJhZwJjBNU2BRwyYdCTmRZu2fr795jCPJB6Io5pjPzAt29ASqy+ODBSRMDKoKGbQ==
+  dependencies:
+    "@rdfjs/types" "*"
+    rdf-data-factory "^1.1.0"
+    relative-to-absolute-iri "^1.0.0"
+    sax "^1.2.4"
 
 react-is@^16.8.1:
   version "16.13.1"
@@ -7318,7 +7598,7 @@ readable-error@^1.0.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@^3, readable-stream@^3.0.6, readable-stream@^3.4.0, readable-stream@^3.5.0, readable-stream@^3.6.0:
+"readable-stream@2 || 3", readable-stream@^3, readable-stream@^3.0.2, readable-stream@^3.0.6, readable-stream@^3.4.0, readable-stream@^3.5.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -7434,6 +7714,11 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+relative-to-absolute-iri@^1.0.0:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.6.tgz#7111dac5730587e3fbca3e0f48585fbc88c147a7"
+  integrity sha512-Xw5/Zx6iWSCMJUXwXVOjySjH8Xli4hVFL9QQFvkl1qEmFBG94J+QUI9emnoctOCD3285f1jNV+QWV9eDYwIdfQ==
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -7448,6 +7733,32 @@ repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
+request@^2.88.0:
+  version "2.88.2"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
+  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.5.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -7607,10 +7918,15 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sax@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 schema-utils@^1.0.0:
   version "1.0.0"
@@ -8029,6 +8345,21 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+sshpk@^1.7.0:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
+  integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
+    ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
+    jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
+    tweetnacl "~0.14.0"
 
 ssri@^6.0.1:
   version "6.0.2"
@@ -8466,6 +8797,14 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+tough-cookie@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
 tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
@@ -8501,6 +8840,18 @@ tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
+  dependencies:
+    safe-buffer "^5.0.1"
+
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+  integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -8729,6 +9080,15 @@ vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
 
 vm-browserify@^1.0.1:
   version "1.1.2"
@@ -9142,6 +9502,11 @@ xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
+xmldom@0.1.19:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.19.tgz#631fc07776efd84118bf25171b37ed4d075a0abc"
+  integrity sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw=
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This PR introduces clownface everywhere the records are processed but more importantly it uses SHACL shape to do proper rendering of result rows

To set up, add a `<link id="result" class="shape">` or `<script id="result" class="shape">` as a child of `<zack-results>`.

```html
<zack-results>
  <!-- 
    use link to load the shape from external URL

    type is not required but can be used as override for the HTTP response
  -->
  <link id="result" class="shape" type="text/turtle" href="./result-shape.ttl">

  <!--
    alternatively, embed the shape's representation directly in a script element
  -->
  <script id="result" class="shape" type="text/turtle">
    The contents must be a SHACL shape in the specified
  </script>
</zack-results>
```

The shape's properties will be mapped to a JS object and passed to rendering templates. The templates are objects of shape's `schema:hasPart` property. They require at least a name and code link

```turtle
[
  sh:property [
    #required
    sh:name "name" ;

    #required
    sh:path schema:name ;
  ],
  schema:hasPart [
    #required
    schema:name "main" ;

    #required
    code:link "/templates/main.js" ;
  ]
]
```

Finally, the template is a JS function which will be loaded dynamically and must be default-exported from the module. For example, the file `/templates/main.js` could look as shown below

```js
/**
 * @this ZackResult element
 * @param context Rendering context
 * @param context.html lit template function
 * @param context.subject graph pointer to record subject
 * @param properties Shape properties
 */
export default function (context, properties) {
  return context.html`<h2>${properties.title}</h2>`
}
```

Styling is possible by targeting CSS parts whose name match the `schema:hasPart/schema:name`. The above would be styled as

```css
zack-results::part(main) {
  color: gray ;
  text-decoration: underline
}
```

Finally, more fine-grained styling is possible by adding more CSS parts in the rendered template. They need to be declared as a second level of `schema:hasPart`

```diff
[
  schema:hasPart [
    schema:name "main" ;
    code:link "/templates/main.js" ;
+   schema:hasPart [ schema:hasName "header" ] ;
  ]
]
```

```diff
export default function (context, properties) {
-  return context.html`<h2>${properties.title}</h2>`
+  return context.html`<h2 part="main-header">${properties.title}</h2>`
}
```

```diff
-zack-results::part(main) {
+zack-results::part(main-header) {
  color: gray ;
  text-decoration: underline
}
```